### PR TITLE
ci(backend): 🔧 triggers for backend pipeline

### DIFF
--- a/.github/workflows/python-backend.yaml
+++ b/.github/workflows/python-backend.yaml
@@ -3,8 +3,18 @@ name : Python backend
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/python-backend.yml'
+      - 'pyproject.toml'
+      - 'uv.lock'
   push:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/python-backend.yml'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   format:


### PR DESCRIPTION
The triggers for thhe backend pipeline are improved. The pipeline for
the backend will only run on changes withing the backend folder and
changes to the uv.lock and pyroject.toml file.