### PR TITLE
chore: 🔧 update dependabot config for backend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   # Enable version updates for Python dependencies
   - package-ecosystem: "uv"
-    directory: "/backend"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
The defined location for the backend was /backend, but the configuration
of the Python packages (uv.lock and pyproject.toml) reside in the root
folder. Therefore dependabot fails it cannot find any dependency file in
the backend directory.