### PR TITLE
feat: add route models

### DIFF
--- a/popupsim/backend/src/configuration/model_route.py
+++ b/popupsim/backend/src/configuration/model_route.py
@@ -1,0 +1,68 @@
+"""
+Models and validation logic for railway route configurations.
+
+This module provides data models and validation rules for handling
+railway routes within the simulation. It includes functionality to manage
+route details such as origin/destination tracks, track sequences, distances,
+and travel times.
+"""
+
+import logging
+from typing import List
+
+from pydantic import BaseModel, Field, model_validator
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+class Route(BaseModel):
+    """Information about a railway route between tracks."""
+
+    route_id: str = Field(description='Unique identifier for the route')
+    from_track: str = Field(description='Track ID where the route starts')
+    to_track: str = Field(description='Track ID where the route ends')
+    track_sequence: List[str] = Field(description='Sequence of tracks forming the complete route')
+    distance_m: float = Field(gt=0, description='Total distance of the route in meters')
+    time_min: int = Field(gt=0, description='Time required to travel the route in minutes')
+
+    @model_validator(mode='before')
+    @classmethod
+    def parse_track_sequence(cls, values):
+        """Parse track_sequence from string to list if needed."""
+        data = dict(values)
+        track_sequence = data.get('track_sequence')
+
+        # If already a list, no need to parse
+        if isinstance(track_sequence, list):
+            return data
+
+        # If string, parse as comma-separated list
+        if isinstance(track_sequence, str):
+            # Remove any quotes that might be present in CSV
+            track_sequence = track_sequence.strip('"\'')
+            data['track_sequence'] = [t.strip() for t in track_sequence.split(',')]
+
+        return data
+
+    @model_validator(mode='after')
+    def validate_route(self) -> 'Route':
+        """Validate route integrity."""
+        # Ensure track_sequence contains at least from_track and to_track
+        first_track = self.track_sequence[0] if self.track_sequence else None
+        last_track = self.track_sequence[-1] if self.track_sequence else None
+
+        if first_track is None or last_track is None:
+            raise ValueError(f'Route {self.route_id} must have a valid track_sequence')
+
+        if not self.track_sequence or len(self.track_sequence) < 2:
+            raise ValueError(f'Route {self.route_id} must have at least two tracks in sequence')
+
+        # Validate that sequence contains at least the from and to tracks
+        if self.from_track not in self.track_sequence:
+            raise ValueError(f'Route {self.route_id} must include from_track "{self.from_track}" in track_sequence')
+
+        if self.to_track not in self.track_sequence:
+            raise ValueError(f'Route {self.route_id} must include to_track "{self.to_track}" in track_sequence')
+
+        return self

--- a/popupsim/backend/src/configuration/model_routes.py
+++ b/popupsim/backend/src/configuration/model_routes.py
@@ -1,0 +1,163 @@
+"""
+Routes loader module for the simulation.
+
+This module provides functionality to load route configurations from CSV files,
+validate them using the Route model, and make them available to the simulation.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import pandas as pd
+
+from .model_route import Route
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+class RoutesConfig:
+    """
+    Routes configuration manager that loads and provides access to route data.
+
+    This class is responsible for loading route configurations from a CSV file,
+    validating them through the Route model, and providing convenient access
+    to route information for the simulation.
+    """
+
+    def __init__(self, routes_file: Optional[Union[str, Path]] = None):
+        """
+        Initialize the routes configuration manager.
+
+        Args:
+            routes_file: Path to the CSV file containing route data. If None, no routes are loaded initially.
+        """
+        self.routes: List[Route] = []
+        self.routes_by_id: Dict[str, Route] = {}
+
+        if routes_file:
+            self.load_routes(routes_file)
+
+    def load_routes(self, csv_path: Union[str, Path]) -> None:
+        """
+        Load routes from a CSV file.
+
+        Args:
+            csv_path: Path to the CSV file containing route data
+
+        Raises:
+            FileNotFoundError: If the CSV file does not exist
+            ValueError: If the CSV file contains invalid route data
+        """
+        path = Path(csv_path)
+        if not path.exists():
+            raise FileNotFoundError(f'Routes file not found: {path}')
+
+        try:
+            logger.info('Loading routes from CSV file: %s', path)
+            df = pd.read_csv(path, sep=';')
+
+            # Validate required columns
+            required_columns = ['route_id', 'from_track', 'to_track', 'track_sequence', 'distance_m', 'time_min']
+            missing_columns = [col for col in required_columns if col not in df.columns]
+            if missing_columns:
+                raise ValueError(f'Missing required columns in CSV: {", ".join(missing_columns)}')
+
+            # Clear existing routes
+            self.routes = []
+            self.routes_by_id = {}
+
+            # Convert DataFrame to list of Route objects
+            for _, row in df.iterrows():
+                try:
+                    track_sequence = row['track_sequence']
+                    track_sequence = track_sequence.replace('"', '').replace("'", '')
+                    track_sequence = [item.strip() for item in track_sequence.split(',')]
+                    # Ensure track_sequence is treated as a string for parsing
+                    route = Route(
+                        route_id=row['route_id'],
+                        from_track=row['from_track'],
+                        to_track=row['to_track'],
+                        track_sequence=track_sequence,
+                        distance_m=row['distance_m'],
+                        time_min=row['time_min'],
+                    )
+                    self.routes.append(route)
+                    self.routes_by_id[route.route_id] = route
+                except Exception as e:
+                    route_id = row.get('route_id', 'unknown')
+                    logger.error('Error parsing route %s: %s', route_id, str(e))
+                    raise ValueError(f'Error parsing route {route_id}: {e!s}') from e
+
+            logger.info('Successfully loaded %d routes from %s', len(self.routes), path)
+
+        except Exception as e:
+            if not isinstance(e, (FileNotFoundError, ValueError)):
+                logger.error('Failed to load routes from CSV: %s', str(e))
+                raise ValueError(f'Failed to load routes from CSV: {e!r}') from e
+            raise
+
+    def get_route(self, route_id: str) -> Route:
+        """
+        Get a route by its ID.
+
+        Args:
+            route_id: The ID of the route to retrieve
+
+        Returns:
+            The Route object with the specified ID
+
+        Raises:
+            KeyError: If no route with the specified ID exists
+        """
+        if route_id not in self.routes_by_id:
+            raise KeyError(f'Route not found: {route_id}')
+
+        return self.routes_by_id[route_id]
+
+    def get_route_between_tracks(self, from_track: str, to_track: str) -> Optional[Route]:
+        """
+        Find a route between two tracks.
+
+        Args:
+            from_track: The starting track ID
+            to_track: The destination track ID
+
+        Returns:
+            The Route object connecting the tracks, or None if no route exists
+        """
+        for route in self.routes:
+            if route.from_track == from_track and route.to_track == to_track:
+                return route
+
+        return None
+
+    def __len__(self) -> int:
+        """Return the number of loaded routes."""
+        return len(self.routes)
+
+    def __iter__(self):
+        """Iterate through all routes."""
+        return iter(self.routes)
+
+
+def load_routes_from_csv(csv_path: Union[str, Path]) -> List[Route]:
+    """
+    Load routes from a CSV file and return as a list of Route objects.
+
+    This is a convenience function that creates a RoutesConfig instance,
+    loads the routes, and returns the list of Route objects.
+
+    Args:
+        csv_path: Path to the CSV file containing route data
+
+    Returns:
+        List of validated Route objects
+
+    Raises:
+        FileNotFoundError: If the CSV file does not exist
+        ValueError: If the CSV file contains invalid route data
+    """
+    routes_config = RoutesConfig(csv_path)
+    return routes_config.routes

--- a/popupsim/backend/tests/fixtures/config/routes.csv
+++ b/popupsim/backend/tests/fixtures/config/routes.csv
@@ -1,0 +1,6 @@
+route_id;from_track;to_track;track_sequence;distance_m;time_min
+ROUTE01;sammelgleis;werkstattzufuehrung;"sammelgleis,werkstattzufuehrung";450;5
+ROUTE02;werkstattzufuehrung;werkstattgleis;"werkstattzufuehrung,werkstattgleis";120;2
+ROUTE03;werkstattgleis;werkstattabfuehrung;"werkstattgleis,werkstattabfuehrung";120;2
+ROUTE04;werkstattabfuehrung;parkgleis;"werkstattabfuehrung,parkgleis";380;4
+ROUTE05;sammelgleis;bahnhofskopf;"sammelgleis,bahnhofskopf";200;3

--- a/popupsim/backend/tests/unit/test_model_route.py
+++ b/popupsim/backend/tests/unit/test_model_route.py
@@ -1,0 +1,167 @@
+"""Unit tests for the Route model."""
+
+import pytest
+
+from src.configuration.model_route import Route
+
+
+@pytest.mark.unit
+class TestRoute:
+    """Test suite for Route model validation and methods."""
+
+    def test_route_initialization(self):
+        """Test that a Route can be created with valid data."""
+        route = Route(
+            route_id='TEST01',
+            from_track='track1',
+            to_track='track2',
+            track_sequence=['track1', 'middle', 'track2'],
+            distance_m=100.5,
+            time_min=5,
+        )
+
+        assert route.route_id == 'TEST01'
+        assert route.from_track == 'track1'
+        assert route.to_track == 'track2'
+        assert route.track_sequence == ['track1', 'middle', 'track2']
+        assert route.distance_m == 100.5
+        assert route.time_min == 5
+
+    def test_parse_track_sequence_from_string(self):
+        """Test that track_sequence can be parsed from string."""
+        route = Route(
+            route_id='TEST02',
+            from_track='track1',
+            to_track='track2',
+            track_sequence='track1,middle,track2',
+            distance_m=100.5,
+            time_min=5,
+        )
+
+        assert isinstance(route.track_sequence, list)
+        assert route.track_sequence == ['track1', 'middle', 'track2']
+
+    def test_parse_track_sequence_with_quotes(self):
+        """Test that track_sequence can be parsed from quoted string."""
+        route = Route(
+            route_id='TEST03',
+            from_track='track1',
+            to_track='track2',
+            track_sequence='"track1,middle,track2"',
+            distance_m=100.5,
+            time_min=5,
+        )
+
+        assert isinstance(route.track_sequence, list)
+        assert route.track_sequence == ['track1', 'middle', 'track2']
+
+    def test_already_list_track_sequence(self):
+        """Test that track_sequence is preserved if already a list."""
+        track_list = ['track1', 'middle', 'track2']
+        route = Route(
+            route_id='TEST04',
+            from_track='track1',
+            to_track='track2',
+            track_sequence=track_list,
+            distance_m=100.5,
+            time_min=5,
+        )
+
+        assert route.track_sequence is not track_list  # Pydantic creates a new list
+        assert route.track_sequence == track_list
+
+    def test_validate_empty_track_sequence(self):
+        """Test that empty track_sequence raises ValueError."""
+        with pytest.raises(ValueError, match='must have a valid track_sequence'):
+            Route(
+                route_id='INVALID01',
+                from_track='track1',
+                to_track='track2',
+                track_sequence=[],
+                distance_m=100.5,
+                time_min=5,
+            )
+
+    def test_validate_short_track_sequence(self):
+        """Test that track_sequence with less than 2 tracks raises ValueError."""
+        with pytest.raises(ValueError, match='must have at least two tracks in sequence'):
+            Route(
+                route_id='INVALID02',
+                from_track='track1',
+                to_track='track2',
+                track_sequence=['only_one'],
+                distance_m=100.5,
+                time_min=5,
+            )
+
+    def test_validate_from_track_not_in_sequence(self):
+        """Test that from_track must be in track_sequence."""
+        with pytest.raises(ValueError, match='must include from_track'):
+            Route(
+                route_id='INVALID03',
+                from_track='not_included',
+                to_track='track2',
+                track_sequence=['track1', 'middle', 'track2'],
+                distance_m=100.5,
+                time_min=5,
+            )
+
+    def test_validate_to_track_not_in_sequence(self):
+        """Test that to_track must be in track_sequence."""
+        with pytest.raises(ValueError, match='must include to_track'):
+            Route(
+                route_id='INVALID04',
+                from_track='track1',
+                to_track='not_included',
+                track_sequence=['track1', 'middle', 'track3'],
+                distance_m=100.5,
+                time_min=5,
+            )
+
+    def test_negative_distance_validation(self):
+        """Test that negative distance_m raises validation error."""
+        with pytest.raises(ValueError, match='distance_m'):
+            Route(
+                route_id='INVALID05',
+                from_track='track1',
+                to_track='track2',
+                track_sequence=['track1', 'track2'],
+                distance_m=-50,
+                time_min=5,
+            )
+
+    def test_zero_distance_validation(self):
+        """Test that zero distance_m raises validation error."""
+        with pytest.raises(ValueError, match='distance_m'):
+            Route(
+                route_id='INVALID06',
+                from_track='track1',
+                to_track='track2',
+                track_sequence=['track1', 'track2'],
+                distance_m=0,
+                time_min=5,
+            )
+
+    def test_negative_time_validation(self):
+        """Test that negative time_min raises validation error."""
+        with pytest.raises(ValueError, match='time_min'):
+            Route(
+                route_id='INVALID07',
+                from_track='track1',
+                to_track='track2',
+                track_sequence=['track1', 'track2'],
+                distance_m=100,
+                time_min=-2,
+            )
+
+    def test_zero_time_validation(self):
+        """Test that zero time_min raises validation error."""
+        with pytest.raises(ValueError, match='time_min'):
+            Route(
+                route_id='INVALID08',
+                from_track='track1',
+                to_track='track2',
+                track_sequence=['track1', 'track2'],
+                distance_m=100,
+                time_min=0,
+            )

--- a/popupsim/backend/tests/unit/test_model_routes.py
+++ b/popupsim/backend/tests/unit/test_model_routes.py
@@ -1,0 +1,155 @@
+"""Unit tests for the RoutesConfig class and related functions."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.configuration.model_route import Route
+from src.configuration.model_routes import RoutesConfig, load_routes_from_csv
+
+
+@pytest.fixture
+def routes_csv_path() -> Path:
+    """Return the path to the test routes CSV file."""
+    return Path(__file__).parent.parent / 'fixtures' / 'config' / 'routes.csv'
+
+
+@pytest.fixture
+def routes_config(routes_csv_path: Path) -> RoutesConfig:
+    """Return a RoutesConfig instance with test data loaded."""
+    return RoutesConfig(routes_csv_path)
+
+
+@pytest.fixture
+def temp_csv_file() -> Path:
+    """Create a temporary CSV file with test route data."""
+    # Create a temporary file
+    return Path(tempfile.mkstemp(suffix='.csv')[1])
+
+
+@pytest.mark.unit
+class TestRoutesConfig:
+    """Test suite for RoutesConfig class."""
+
+    def test_init_with_file(self, routes_csv_path: Path):
+        """Test initialization with a file path."""
+        config = RoutesConfig(routes_csv_path)
+        assert len(config.routes) == 5
+        assert len(config.routes_by_id) == 5
+        assert 'ROUTE01' in config.routes_by_id
+
+    def test_init_without_file(self):
+        """Test initialization without a file path."""
+        config = RoutesConfig()
+        assert len(config.routes) == 0
+        assert len(config.routes_by_id) == 0
+
+    def test_init_with_string_path(self, routes_csv_path: Path):
+        """Test initialization with a string path."""
+        config = RoutesConfig(str(routes_csv_path))
+        assert len(config.routes) == 5
+
+    def test_load_routes(self, routes_csv_path: Path):
+        """Test loading routes from CSV."""
+        config = RoutesConfig()
+        assert len(config.routes) == 0
+
+        config.load_routes(routes_csv_path)
+        assert len(config.routes) == 5
+
+        # Test that reload clears previous data
+        config.load_routes(routes_csv_path)
+        assert len(config.routes) == 5
+
+    def test_load_nonexistent_file(self):
+        """Test loading from a nonexistent file."""
+        config = RoutesConfig()
+        with pytest.raises(FileNotFoundError, match='Routes file not found'):
+            config.load_routes('nonexistent_file.csv')
+
+    def test_invalid_csv_format(self, tmp_path: Path):
+        """Test loading from a CSV with missing required columns."""
+        # Create a CSV file with missing columns
+        invalid_csv = tmp_path / 'invalid.csv'
+        invalid_csv.write_text('route_id,from_track\nROUTE01,track1')
+
+        config = RoutesConfig()
+        with pytest.raises(ValueError, match='Missing required columns in CSV'):
+            config.load_routes(invalid_csv)
+
+    def test_invalid_route_data(self, temp_csv_file: Path):
+        """Test loading routes with invalid data."""
+        # Create a CSV file with invalid route data (negative distance)
+        temp_csv_file.write_text(
+            'route_id;from_track;to_track;track_sequence;distance_m;time_min\n'
+            'INVALID;track1;track2;"track1,track2";-100;5'
+        )
+
+        config = RoutesConfig()
+        with pytest.raises(ValueError, match='Error parsing route INVALID'):
+            config.load_routes(temp_csv_file)
+
+    def test_get_route(self, routes_config: RoutesConfig):
+        """Test getting a route by ID."""
+        route = routes_config.get_route('ROUTE01')
+        assert isinstance(route, Route)
+        assert route.route_id == 'ROUTE01'
+        assert route.from_track == 'sammelgleis'
+        assert route.to_track == 'werkstattzufuehrung'
+
+    def test_get_nonexistent_route(self, routes_config: RoutesConfig):
+        """Test getting a nonexistent route."""
+        with pytest.raises(KeyError, match='Route not found'):
+            routes_config.get_route('NONEXISTENT')
+
+    def test_get_route_between_tracks(self, routes_config: RoutesConfig):
+        """Test finding a route between two tracks."""
+        route = routes_config.get_route_between_tracks('sammelgleis', 'werkstattzufuehrung')
+        assert route is not None
+        assert route.route_id == 'ROUTE01'
+
+    def test_get_nonexistent_route_between_tracks(self, routes_config: RoutesConfig):
+        """Test finding a nonexistent route between tracks."""
+        route = routes_config.get_route_between_tracks('nonexistent', 'track')
+        assert route is None
+
+    def test_len_method(self, routes_config: RoutesConfig):
+        """Test the __len__ method."""
+        assert len(routes_config) == 5
+
+    def test_iter_method(self, routes_config: RoutesConfig):
+        """Test the __iter__ method."""
+        routes = list(routes_config)
+        assert len(routes) == 5
+        assert all(isinstance(route, Route) for route in routes)
+
+    def test_csv_malformed_data(self, temp_csv_file: Path):
+        """Test handling of malformed CSV data."""
+        temp_csv_file.write_text('This is not a CSV file')
+
+        config = RoutesConfig()
+        with pytest.raises(ValueError, match='Missing required columns in CSV'):
+            config.load_routes(temp_csv_file)
+
+
+@pytest.mark.unit
+class TestLoadRoutesFromCSV:
+    """Test suite for the load_routes_from_csv function."""
+
+    def test_load_routes_from_csv(self, routes_csv_path: Path):
+        """Test loading routes from CSV using the convenience function."""
+        routes = load_routes_from_csv(routes_csv_path)
+        assert isinstance(routes, list)
+        assert len(routes) == 5
+        assert all(isinstance(route, Route) for route in routes)
+
+    def test_load_routes_from_nonexistent_file(self):
+        """Test loading from a nonexistent file."""
+        with pytest.raises(FileNotFoundError):
+            load_routes_from_csv('nonexistent_file.csv')
+
+    def test_load_routes_with_string_path(self, routes_csv_path: Path):
+        """Test loading using a string path."""
+        routes = load_routes_from_csv(str(routes_csv_path))
+        assert len(routes) == 5


### PR DESCRIPTION
## Summary
add Models for routes and some tests for them

## Related Issues/Tickets
[Story 1.4b: Routes CSV Loader](https://github.com/OpenRailAssociation/dac-migration-dss-popupsim/issues/51)
[Story 1.4b: Routes CSV Loader](https://github.com/OpenRailAssociation/dac-migration-dss-popupsim/issues/55)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test improvement
- [ ] Other (please describe):

## How Has This Been Tested?
yes with uv run pytest

## Checklist
- [x] Follows conventional commit message format
- [x] Code is formatted and linted (`uv run ruff format . && uv run ruff check .`)
- [x] All tests pass (`uv run pytest`)
- [x] Documentation updated (if needed)

## Additional Notes
both tickets can be closed but have discussions
