### PR TITLE
chore(backend): 🐛 fix pre-commit for Windows.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,7 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-merge-conflict
-      - id: mixed-line-ending
-        args: [--fix=lf]
+
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0
@@ -16,7 +15,7 @@ repos:
       - id: ruff-format
         files: ^popupsim/backend/
       - id: ruff
-        files: ^backend/
+        files: ^popupsim/backend/
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/setup/dev/set_commit_msg_hooks.py
+++ b/setup/dev/set_commit_msg_hooks.py
@@ -1,23 +1,43 @@
 #!/usr/bin/env python3
-import os
-import stat
+"""Setup script for installing Git commit message validation hooks.
 
-COMMIT_MSG_HOOK = """#!/usr/bin/env python3
+This script creates platform-specific Git hooks that validate commit messages
+against the Conventional Commits format to ensure consistent commit history.
+"""
+import platform
+import stat
 import sys
+from pathlib import Path
+
+
+def create_validation_script() -> str:
+    """Create a separate Python validation script for commit message validation.
+
+    Returns
+    -------
+    str
+        Path to the created validation script.
+    """
+    # Add shebang only for Unix-like systems
+    shebang = "#!/usr/bin/env python3\n" if platform.system() != "Windows" else ""
+
+    # Define commit types
+    commit_types = "feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert"
+
+    script_content = f"""{shebang}import sys
 import re
 
 def validate_commit_message(commit_msg_file):
-    with open(commit_msg_file, 'r') as f:
+    with open(commit_msg_file, "r") as f:
         commit_msg = f.read().strip()
 
-    # Skip merge commits
-    if commit_msg.startswith('Merge'):
+    if commit_msg.startswith("Merge"):
         return True
 
-    pattern = r'^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\(.+\))?!?: .{1,}'
+    pattern = r"^({commit_types})(\\(.+\\))?!?: .{{1,}}"
 
     if not re.match(pattern, commit_msg):
-        print("\\n❌ Commit message does not follow Conventional Commits format!\\n")
+        print("\\nERROR: Commit message does not follow Conventional Commits format!\\n")
         print("Format: <type>[optional scope]: <description>\\n")
         print("Types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert\\n")
         print("Examples:")
@@ -33,25 +53,63 @@ if __name__ == "__main__":
         sys.exit(1)
 """
 
+    script_path = Path('.git') / 'hooks' / 'validate_commit_msg.py'
+    script_path.write_text(script_content, encoding='utf-8')
+    return str(script_path)
 
-def setup_commit_msg_hook():
-    hooks_dir = ".git/hooks"
-    hook_path = os.path.join(hooks_dir, "commit-msg")
 
-    if not os.path.exists(hooks_dir):
-        print("❌ Not a git repository")
+def get_commit_msg_hook(script_path: str) -> str:
+    """Generate platform-specific commit message hook content.
+
+    Parameters
+    ----------
+    script_path : str
+        Path to the validation script.
+
+    Returns
+    -------
+    str
+        Hook content appropriate for the current platform.
+    """
+    python_exe = sys.executable
+
+    if platform.system() == 'Windows':
+        return f'@echo off\n"{python_exe}" "{script_path}" %1\n'
+    return f'#!/bin/bash\n"{python_exe}" "{script_path}" "$1"\n'
+
+
+def setup_commit_msg_hook() -> bool:
+    """Install Git commit message validation hook for the current platform.
+
+    Returns
+    -------
+    bool
+        True if installation succeeded, False otherwise.
+    """
+    hooks_dir = Path('.git') / 'hooks'
+
+    if not hooks_dir.exists():
+        print('ERROR: Not a git repository')
         return False
 
-    with open(hook_path, "w") as f:
-        f.write(COMMIT_MSG_HOOK)
+    # Create validation script
+    script_path = create_validation_script()
 
-    # Make executable
-    st = os.stat(hook_path)
-    os.chmod(hook_path, st.st_mode | stat.S_IEXEC)
+    # Create hook file
+    hook_name = 'commit-msg.bat' if platform.system() == 'Windows' else 'commit-msg'
+    hook_path = hooks_dir / hook_name
 
-    print("✅ Commit message hook installed successfully!")
+    commit_msg_hook = get_commit_msg_hook(script_path)
+    hook_path.write_text(commit_msg_hook, encoding='utf-8')
+
+    # Make executable (Unix/Linux/macOS only)
+    if platform.system() != 'Windows':
+        st = hook_path.stat()
+        hook_path.chmod(st.st_mode | stat.S_IEXEC)
+
+    print('SUCCESS: Commit message hook installed successfully!')
     return True
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     setup_commit_msg_hook()


### PR DESCRIPTION
The existing setup script for installing the precommit-hooks did not work on Windows due to issues in character encoding and issues in the regex. The file is adopted to our coding style.

The configuration of the mixed-line ending of the pre-commit hook is altered. Detection / setting of the line ending is removed since it is driven by the .gitattributes file.

This fixes #111
