### PR TITLE
ci(backend): 🐛 add permissions for sarif upload

### DIFF
--- a/.github/workflows/python-backend.yaml
+++ b/.github/workflows/python-backend.yaml
@@ -44,6 +44,8 @@ jobs:
     name: Ruff Linting
     needs: format
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1


### PR DESCRIPTION
## Summary
The SARIF upload for the Ruff job failed due to missing configuration of permissions

## Related Issues/Tickets
None

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test improvement
- [X] Other (please describe): CI/CD

## How Has This Been Tested?
Unfortunately testing is not possible in advance

## Checklist
- [X] Follows conventional commit message format
- [X] Code is formatted and linted (`uv run ruff format . && uv run ruff check .`)
- [X] All tests pass (`uv run pytest`)
- [ X Documentation updated (if needed)

## Additional Notes


